### PR TITLE
Switch resume link to new location

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -36,7 +36,7 @@
                             </a>
                         </li>
                         <li>
-                            <a href="https://stackoverflow.com/cv/kbrown">
+                            <a href="https://kevin-brown.com/cv">
                                 <i class="fa fa-file-text"></i>
                                 R&eacute;sum&eacute;
                             </a>


### PR DESCRIPTION
This should be easier to update in the future as things change.